### PR TITLE
Add nested error support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ subclasses of `Error` for **custom error classes** with the correct `name` and
   standard `Error` behavior in tact.
 - Add **extra properties** to the error by just passing in an object.
 - StandardError.js sets the error's **stack trace correctly**, even if your
-  error class **subclasses/inherits** from StandardError.  
+  error class **subclasses/inherits** from StandardError.
   Just inheriting from `Error` with `Object.create` breaks the stack trace.
 - Every `StandardError` instance is also an instance of `Error`.
-- Serializes all expected properties when passing it to `JSON.stringify`.  
+- Serializes all expected properties when passing it to `JSON.stringify`.
   Did you know that the default `Error` object serializes to an empty object
   (`{}`)?
 - Works both in Node.js and browsers and sets the stack trace via
@@ -44,7 +44,7 @@ throw new StandardError("Not Found", {code: 404})
 ```
 
 The thrown instance of `StandardError` will then have both the `message` and the
-`code` property.  
+`code` property.
 It'll also also have a `name` property set to `"StandardError"`.
 
 You can skip the explicit `message` argument and give everything as an
@@ -82,6 +82,29 @@ HttpError.prototype = Object.create(StandardError.prototype, {
 example. First, that's the proper way to subclass in JavaScript and second,
 StandardError.js depends on that to know which functions to skip in the stack
 trace.
+
+### Including the previous error event
+StandardError.js allows you to pass a previous error and automatically appends
+its stack to the current error. This is great for throwing custom errors but
+still being able to understand the context from where the original error was
+thrown.
+
+```javascript
+fs.readFile(file, function (err, data) {
+  if (err) throw new StandardError({message: "File Not Found"}, err)
+  console.log(data)
+})
+
+//  if (err) throw new StandardError({message: "File Not Found"}, err)
+//                  ^
+// StandardError: File Not Found
+//     at file.js:4:18
+//     at fs.js:241:20
+//     at FSReqWrap.oncomplete (fs.js:72:15)
+// From previous event:
+// Error: ENOENT: no such file or directory, open '/eheh'
+//     at Error (native)
+```
 
 #### Name
 
@@ -121,7 +144,7 @@ For more convoluted language, see the `LICENSE` file.
 
 About
 -----
-**[Andri Möll](http://themoll.com)** typed this and the code.  
+**[Andri Möll](http://themoll.com)** typed this and the code.
 [Monday Calendar](https://mondayapp.com) supported the engineering work.
 
 If you find StandardError.js needs improving, please don't hesitate to type to

--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
+var define = Object.defineProperty;
 var has = Object.hasOwnProperty
+var objProto = Object.prototype;
 var proto = Object.getPrototypeOf
 var trace = Error.captureStackTrace
 module.exports = StandardError
 
-function StandardError(msg, props) {
+function StandardError(msg, props, inner) {
   // Let all properties be enumerable for easier serialization.
-  if (msg && typeof msg == "object") props = msg, msg = undefined
+  if (props instanceof Error) inner = props, props = undefined
+  if (msg && msg instanceof Object && proto(msg) == objProto) props = msg
   else this.message = msg
 
   // Name has to be an own property (or on the prototype a single step up) for
@@ -15,6 +18,20 @@ function StandardError(msg, props) {
     this.name = has.call(proto(this), "name")? this.name : this.constructor.name
 
   if (trace && !("stack" in this)) trace(this, this.constructor)
+  if (inner) {
+    var stack = this.stack;
+
+    define(this, "inner", { value: inner, enumerable: false });
+    define(this, "stack", {
+      get: function() {
+        if (this.inner) {
+          stack += "\nFrom previous event:\n" + this.inner.stack;
+        }
+
+        return stack;
+      }
+    });
+  }
 }
 
 StandardError.prototype = Object.create(Error.prototype, {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -81,6 +81,47 @@ describe("StandardError", function() {
       stack[2].must.not.include("index_test.js")
     })
 
+    it("must extend stack when inner error is set", function() {
+      var stdErr = new StandardError()
+      var err = new ChildError('foo', stdErr)
+      err.must.have.own("stack")
+
+      var stack = err.stack.split(/\n\s*/)
+      stack[0].must.equal("ChildError: foo")
+      stack[1].must.include("index_test.js")
+      stack[2].must.not.include("index_test.js")
+      stack.must.contain('StandardError');
+      stack.must.contain('From previous event:')
+    })
+
+    it("must extend stack when object and inner error are set", function() {
+      var stdErr = new StandardError()
+      var err = new ChildError({ code: 500 }, stdErr)
+      err.must.have.own("code", 500)
+      err.must.have.own("stack")
+
+      var stack = err.stack.split(/\n\s*/)
+      stack[0].must.equal("ChildError")
+      stack[1].must.include("index_test.js")
+      stack[2].must.not.include("index_test.js")
+      stack.must.contain('StandardError');
+      stack.must.contain('From previous event:')
+    })
+
+    it("must extend stack when message, object and inner error are set", function() {
+      var stdErr = new StandardError()
+      var err = new ChildError('foo', { code: 500 }, stdErr)
+      err.must.have.own("code", 500)
+      err.must.have.own("stack")
+
+      var stack = err.stack.split(/\n\s*/)
+      stack[0].must.equal("ChildError: foo")
+      stack[1].must.include("index_test.js")
+      stack[2].must.not.include("index_test.js")
+      stack.must.contain('StandardError');
+      stack.must.contain('From previous event:')
+    })
+
     it("must set stack given name from object", function() {
       var err = new StandardError({name: "FallacyError"})
       err.must.have.own("stack")

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -37,7 +37,7 @@ describe("StandardError", function() {
       new StandardError().must.have.own("name", "StandardError")
     })
 
-    it("must set name given emtpy object", function() {
+    it("must set name given empty object", function() {
       new StandardError({}).must.have.own("name", "StandardError")
     })
 


### PR DESCRIPTION
Sometimes the original context of an error is lost due to throwing a new error without taking into consideration the previous error. This PR appends the previous error stack to help with that:

``` js
throw new StandardError({message: "File Not Found"}, err)
```
